### PR TITLE
[BugFix] Fix Terraform variables and harden Grafana config

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,6 +52,9 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_SERVER_ROOT_URL=https://nadzu.localhost/nadun/grafana/
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+      - GF_ANALYTICS_CHECK_FOR_UPDATES=false
+      - GF_DASHBOARDS_NEWS_FEED_ENABLED=false
     ports:
       - "3000:3000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,9 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
       - GF_SERVER_ROOT_URL=https://${PRODUCTION_DOMAIN}/nadun/grafana/
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+      - GF_ANALYTICS_CHECK_FOR_UPDATES=false
+      - GF_DASHBOARDS_NEWS_FEED_ENABLED=false
     volumes:
       - <grafana-provisioning-folder>:/etc/grafana/provisioning
     depends_on:

--- a/infra/common/cloud-init.template
+++ b/infra/common/cloud-init.template
@@ -70,6 +70,9 @@ write_files:
             - GF_USERS_ALLOW_SIGN_UP=false
             - GF_SERVER_SERVE_FROM_SUB_PATH=true
             - GF_SERVER_ROOT_URL=https://${PRODUCTION_DOMAIN}/nadun/grafana/
+            - GF_ANALYTICS_REPORTING_ENABLED=false
+            - GF_ANALYTICS_CHECK_FOR_UPDATES=false
+            - GF_DASHBOARDS_NEWS_FEED_ENABLED=false
           volumes:
             - /opt/app/grafana/provisioning:/etc/grafana/provisioning
           depends_on:

--- a/infra/digitalocean/accounts/naduns-team/variables.tf
+++ b/infra/digitalocean/accounts/naduns-team/variables.tf
@@ -229,20 +229,27 @@ variable "GRAFANA_ADMIN_PASSWORD" {
   type        = string
   sensitive   = true
 }
-variable "YTDLP_DASHBOARD_URL" {
-  //VAR: Expected to be set via Makefile (make tf) as TF_VAR_YTDLP_DASHBOARD_URL. never Declare
-  description = "Presigned URL to download ytdlp dashboard json"
-  type        = string
-}
-
-variable "CAPTCHA_SECURITY_DASHBOARD_URL" {
-  //VAR: Expected to be set via Makefile (make tf) as TF_VAR_CAPTCHA_SECURITY_DASHBOARD_URL. never Declare
-  description = "Presigned URL to download captcha security dashboard json"
-  type        = string
-}
 
 variable "CADDY_CUSTOM_BROWSE_FILE_URL" {
   //VAR: Expected to be set via Makefile (make tf) as TF_VAR_CADDY_CUSTOM_BROWSE_FILE_URL. never Declare
   description = "Presigned URL to download custom browse.html"
+  type        = string
+}
+
+variable "API_HEALTH_DASHBOARD_URL" {
+  //VAR: Expected to be set via Makefile (make tf) as TF_VAR_API_HEALTH_DASHBOARD_URL. never Declare
+  description = "Presigned URL to download api-health.json"
+  type        = string
+}
+
+variable "SECURITY_OVERVIEW_DASHBOARD_URL" {
+  //VAR: Expected to be set via Makefile (make tf) as TF_VAR_SECURITY_OVERVIEW_DASHBOARD_URL. never Declare
+  description = "Presigned URL to download security-overview.json"
+  type        = string
+}
+
+variable "DOMAIN_SERVICES_DASHBOARD_URL" {
+  //VAR: Expected to be set via Makefile (make tf) as TF_VAR_DOMAIN_SERVICES_DASHBOARD_URL. never Declare
+  description = "Presigned URL to download domain-services.json"
   type        = string
 }

--- a/infra/digitalocean/components/variables.tf
+++ b/infra/digitalocean/components/variables.tf
@@ -233,14 +233,21 @@ variable "GRAFANA_ADMIN_PASSWORD" {
   sensitive   = true
 }
 
-variable "YTDLP_DASHBOARD_URL" {
-  //VAR: Expected to be set via Makefile (make tf) as TF_VAR_YTDLP_DASHBOARD_URL. never Declare
-  description = "Presigned URL to download ytdlp dashboard json"
+variable "API_HEALTH_DASHBOARD_URL" {
+  //VAR: Expected to be set via Makefile (make tf) as TF_VAR_API_HEALTH_DASHBOARD_URL. never Declare
+  description = "Presigned URL to download api-health.json"
   type        = string
 }
 
-variable "CAPTCHA_SECURITY_DASHBOARD_URL" {
-  //VAR: Expected to be set via Makefile (make tf) as TF_VAR_CAPTCHA_SECURITY_DASHBOARD_URL. never Declare
-  description = "Presigned URL to download captcha security dashboard json"
+variable "SECURITY_OVERVIEW_DASHBOARD_URL" {
+  //VAR: Expected to be set via Makefile (make tf) as TF_VAR_SECURITY_OVERVIEW_DASHBOARD_URL. never Declare
+  description = "Presigned URL to download security-overview.json"
   type        = string
 }
+
+variable "DOMAIN_SERVICES_DASHBOARD_URL" {
+  //VAR: Expected to be set via Makefile (make tf) as TF_VAR_DOMAIN_SERVICES_DASHBOARD_URL. never Declare
+  description = "Presigned URL to download domain-services.json"
+  type        = string
+}
+


### PR DESCRIPTION
## Description
Fixes 'Unsupported argument' errors in Terraform by adding missing dashboard URL variables to the components module. Hardens Grafana by disabling telemetry, update checks, and the news feed.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Tested with \	f plan\ to verify variables are correctly recognized.
- [x] Verified environment variables in docker-compose.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled Grafana analytics reporting, update checks, and news feed across deployment configurations.
  * Updated dashboard configuration with new monitoring dashboards for API health, security overview, and domain services; removed deprecated dashboard references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nxdun/rust-codebase/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->